### PR TITLE
Add ebench replication controller

### DIFF
--- a/ebench-rc.yaml
+++ b/ebench-rc.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: ebench
+  labels:
+    name: ebench
+spec:
+  replicas: 1
+  selector:
+    name: ebench
+  template:
+    metadata:
+      labels:
+        name: ebench
+    spec:
+      containers:
+      - name: ebench
+        image: enmasseproject/ebench:latest
+        env:
+        - name: BENCH_DURATION
+          value: "60"
+        - name : BENCH_MSG_SIZE
+          value: "128"
+        - name : BENCH_ADDRESS
+          value: anycast
+        - name : BENCH_CLIENTS
+          value: "1"


### PR DESCRIPTION
Allows us to run ebench continuously in a performance test cluster