### PR TITLE
Refactor templates to decouple deployment from configmap

### DIFF
--- a/generated/direct-template.yaml
+++ b/generated/direct-template.yaml
@@ -9,13 +9,13 @@ objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    name: "${NAME}"
+    name: address-config-${NAME}
     labels:
       app: enmasse
       type: address-config
-      address: "${ADDRESS}"
-      store_and_forward: 'false'
-      multicast: "${MULTICAST}"
+      group_id: "${NAME}"
+  data:
+    "${ADDRESS}": '{"store_and_forward":false, "multicast": ${MULTICAST}}'
 parameters:
 - name: NAME
   description: A valid name for the instance

--- a/generated/enmasse-base-template.yaml
+++ b/generated/enmasse-base-template.yaml
@@ -10,7 +10,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: queue
       app: enmasse
     name: queue-inmemory
   objects:
@@ -18,11 +17,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'false'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -71,6 +67,16 @@ objects:
             kind: ImageStreamTag
             name: artemis:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -88,7 +94,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: queue
       app: enmasse
     name: queue-persisted
   objects:
@@ -108,11 +113,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'false'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -162,6 +164,16 @@ objects:
             kind: ImageStreamTag
             name: artemis:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -179,7 +191,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: topic
       app: enmasse
     name: topic-inmemory
   objects:
@@ -187,11 +198,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'true'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -295,6 +303,16 @@ objects:
             kind: ImageStreamTag
             name: topic-forwarder:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -312,7 +330,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: topic
       app: enmasse
     name: topic-persisted
   objects:
@@ -332,11 +349,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'true'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -441,6 +455,16 @@ objects:
             kind: ImageStreamTag
             name: topic-forwarder:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -462,15 +486,15 @@ objects:
     name: direct
   objects:
   - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward":false, "multicast": ${MULTICAST}}'
     kind: ConfigMap
     metadata:
       labels:
-        address: "${ADDRESS}"
         app: enmasse
-        multicast: "${MULTICAST}"
-        store_and_forward: 'false'
+        group_id: "${NAME}"
         type: address-config
-      name: "${NAME}"
+      name: address-config-${NAME}
   parameters:
   - description: A valid name for the instance
     name: NAME

--- a/generated/enmasse-template.yaml
+++ b/generated/enmasse-template.yaml
@@ -10,7 +10,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: queue
       app: enmasse
     name: queue-inmemory
   objects:
@@ -18,11 +17,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'false'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -71,6 +67,16 @@ objects:
             kind: ImageStreamTag
             name: artemis:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -88,7 +94,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: queue
       app: enmasse
     name: queue-persisted
   objects:
@@ -108,11 +113,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'false'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -162,6 +164,16 @@ objects:
             kind: ImageStreamTag
             name: artemis:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -179,7 +191,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: topic
       app: enmasse
     name: topic-inmemory
   objects:
@@ -187,11 +198,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'true'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -295,6 +303,16 @@ objects:
             kind: ImageStreamTag
             name: topic-forwarder:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -312,7 +330,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: topic
       app: enmasse
     name: topic-persisted
   objects:
@@ -332,11 +349,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'true'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -441,6 +455,16 @@ objects:
             kind: ImageStreamTag
             name: topic-forwarder:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -462,15 +486,15 @@ objects:
     name: direct
   objects:
   - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward":false, "multicast": ${MULTICAST}}'
     kind: ConfigMap
     metadata:
       labels:
-        address: "${ADDRESS}"
         app: enmasse
-        multicast: "${MULTICAST}"
-        store_and_forward: 'false'
+        group_id: "${NAME}"
         type: address-config
-      name: "${NAME}"
+      name: address-config-${NAME}
   parameters:
   - description: A valid name for the instance
     name: NAME

--- a/generated/queue-inmemory-template.yaml
+++ b/generated/queue-inmemory-template.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Template
 metadata:
   labels:
-    addressType: queue
     app: enmasse
   name: queue-inmemory
 objects:
@@ -11,11 +10,8 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      address: "${ADDRESS}"
+      address_config: address-config-${NAME}
       app: enmasse
-      multicast: 'false'
-      store_and_forward: 'true'
-      type: address-config
     name: "${NAME}"
   spec:
     replicas: 1
@@ -64,6 +60,16 @@ objects:
           kind: ImageStreamTag
           name: artemis:latest
       type: ImageChange
+- apiVersion: v1
+  data:
+    "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: enmasse
+      group_id: "${NAME}"
+      type: address-config
+    name: address-config-${NAME}
 parameters:
 - description: Storage capacity required for volume claims
   name: STORAGE_CAPACITY

--- a/generated/queue-persisted-template.yaml
+++ b/generated/queue-persisted-template.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Template
 metadata:
   labels:
-    addressType: queue
     app: enmasse
   name: queue-persisted
 objects:
@@ -23,11 +22,8 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      address: "${ADDRESS}"
+      address_config: address-config-${NAME}
       app: enmasse
-      multicast: 'false'
-      store_and_forward: 'true'
-      type: address-config
     name: "${NAME}"
   spec:
     replicas: 1
@@ -77,6 +73,16 @@ objects:
           kind: ImageStreamTag
           name: artemis:latest
       type: ImageChange
+- apiVersion: v1
+  data:
+    "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: enmasse
+      group_id: "${NAME}"
+      type: address-config
+    name: address-config-${NAME}
 parameters:
 - description: Storage capacity required for volume claims
   name: STORAGE_CAPACITY

--- a/generated/tls-enmasse-base-template.yaml
+++ b/generated/tls-enmasse-base-template.yaml
@@ -10,7 +10,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: queue
       app: enmasse
     name: tls-queue-inmemory
   objects:
@@ -18,11 +17,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'false'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -74,6 +70,16 @@ objects:
             kind: ImageStreamTag
             name: artemis:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -91,7 +97,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: queue
       app: enmasse
     name: tls-queue-persisted
   objects:
@@ -111,11 +116,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'false'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -168,6 +170,16 @@ objects:
             kind: ImageStreamTag
             name: artemis:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -185,7 +197,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: topic
       app: enmasse
     name: tls-topic-inmemory
   objects:
@@ -193,11 +204,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'true'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -311,6 +319,16 @@ objects:
             kind: ImageStreamTag
             name: topic-forwarder:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -328,7 +346,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: topic
       app: enmasse
     name: tls-topic-persisted
   objects:
@@ -348,11 +365,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'true'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -467,6 +481,16 @@ objects:
             kind: ImageStreamTag
             name: topic-forwarder:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -488,15 +512,15 @@ objects:
     name: direct
   objects:
   - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward":false, "multicast": ${MULTICAST}}'
     kind: ConfigMap
     metadata:
       labels:
-        address: "${ADDRESS}"
         app: enmasse
-        multicast: "${MULTICAST}"
-        store_and_forward: 'false'
+        group_id: "${NAME}"
         type: address-config
-      name: "${NAME}"
+      name: address-config-${NAME}
   parameters:
   - description: A valid name for the instance
     name: NAME

--- a/generated/tls-enmasse-template.yaml
+++ b/generated/tls-enmasse-template.yaml
@@ -10,7 +10,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: queue
       app: enmasse
     name: tls-queue-inmemory
   objects:
@@ -18,11 +17,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'false'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -74,6 +70,16 @@ objects:
             kind: ImageStreamTag
             name: artemis:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -91,7 +97,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: queue
       app: enmasse
     name: tls-queue-persisted
   objects:
@@ -111,11 +116,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'false'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -168,6 +170,16 @@ objects:
             kind: ImageStreamTag
             name: artemis:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -185,7 +197,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: topic
       app: enmasse
     name: tls-topic-inmemory
   objects:
@@ -193,11 +204,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'true'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -311,6 +319,16 @@ objects:
             kind: ImageStreamTag
             name: topic-forwarder:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -328,7 +346,6 @@ objects:
   kind: Template
   metadata:
     labels:
-      addressType: topic
       app: enmasse
     name: tls-topic-persisted
   objects:
@@ -348,11 +365,8 @@ objects:
     kind: DeploymentConfig
     metadata:
       labels:
-        address: "${ADDRESS}"
+        address_config: address-config-${NAME}
         app: enmasse
-        multicast: 'true'
-        store_and_forward: 'true'
-        type: address-config
       name: "${NAME}"
     spec:
       replicas: 1
@@ -467,6 +481,16 @@ objects:
             kind: ImageStreamTag
             name: topic-forwarder:latest
         type: ImageChange
+  - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: enmasse
+        group_id: "${NAME}"
+        type: address-config
+      name: address-config-${NAME}
   parameters:
   - description: Storage capacity required for volume claims
     name: STORAGE_CAPACITY
@@ -488,15 +512,15 @@ objects:
     name: direct
   objects:
   - apiVersion: v1
+    data:
+      "${ADDRESS}": '{"store_and_forward":false, "multicast": ${MULTICAST}}'
     kind: ConfigMap
     metadata:
       labels:
-        address: "${ADDRESS}"
         app: enmasse
-        multicast: "${MULTICAST}"
-        store_and_forward: 'false'
+        group_id: "${NAME}"
         type: address-config
-      name: "${NAME}"
+      name: address-config-${NAME}
   parameters:
   - description: A valid name for the instance
     name: NAME

--- a/generated/tls-queue-inmemory-template.yaml
+++ b/generated/tls-queue-inmemory-template.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Template
 metadata:
   labels:
-    addressType: queue
     app: enmasse
   name: tls-queue-inmemory
 objects:
@@ -11,11 +10,8 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      address: "${ADDRESS}"
+      address_config: address-config-${NAME}
       app: enmasse
-      multicast: 'false'
-      store_and_forward: 'true'
-      type: address-config
     name: "${NAME}"
   spec:
     replicas: 1
@@ -67,6 +63,16 @@ objects:
           kind: ImageStreamTag
           name: artemis:latest
       type: ImageChange
+- apiVersion: v1
+  data:
+    "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: enmasse
+      group_id: "${NAME}"
+      type: address-config
+    name: address-config-${NAME}
 parameters:
 - description: Storage capacity required for volume claims
   name: STORAGE_CAPACITY

--- a/generated/tls-queue-persisted-template.yaml
+++ b/generated/tls-queue-persisted-template.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Template
 metadata:
   labels:
-    addressType: queue
     app: enmasse
   name: tls-queue-persisted
 objects:
@@ -23,11 +22,8 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      address: "${ADDRESS}"
+      address_config: address-config-${NAME}
       app: enmasse
-      multicast: 'false'
-      store_and_forward: 'true'
-      type: address-config
     name: "${NAME}"
   spec:
     replicas: 1
@@ -80,6 +76,16 @@ objects:
           kind: ImageStreamTag
           name: artemis:latest
       type: ImageChange
+- apiVersion: v1
+  data:
+    "${ADDRESS}": '{"store_and_forward": true, "multicast": false}'
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: enmasse
+      group_id: "${NAME}"
+      type: address-config
+    name: address-config-${NAME}
 parameters:
 - description: Storage capacity required for volume claims
   name: STORAGE_CAPACITY

--- a/generated/tls-topic-inmemory-template.yaml
+++ b/generated/tls-topic-inmemory-template.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Template
 metadata:
   labels:
-    addressType: topic
     app: enmasse
   name: tls-topic-inmemory
 objects:
@@ -11,11 +10,8 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      address: "${ADDRESS}"
+      address_config: address-config-${NAME}
       app: enmasse
-      multicast: 'true'
-      store_and_forward: 'true'
-      type: address-config
     name: "${NAME}"
   spec:
     replicas: 1
@@ -129,6 +125,16 @@ objects:
           kind: ImageStreamTag
           name: topic-forwarder:latest
       type: ImageChange
+- apiVersion: v1
+  data:
+    "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: enmasse
+      group_id: "${NAME}"
+      type: address-config
+    name: address-config-${NAME}
 parameters:
 - description: Storage capacity required for volume claims
   name: STORAGE_CAPACITY

--- a/generated/tls-topic-persisted-template.yaml
+++ b/generated/tls-topic-persisted-template.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Template
 metadata:
   labels:
-    addressType: topic
     app: enmasse
   name: tls-topic-persisted
 objects:
@@ -23,11 +22,8 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      address: "${ADDRESS}"
+      address_config: address-config-${NAME}
       app: enmasse
-      multicast: 'true'
-      store_and_forward: 'true'
-      type: address-config
     name: "${NAME}"
   spec:
     replicas: 1
@@ -142,6 +138,16 @@ objects:
           kind: ImageStreamTag
           name: topic-forwarder:latest
       type: ImageChange
+- apiVersion: v1
+  data:
+    "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: enmasse
+      group_id: "${NAME}"
+      type: address-config
+    name: address-config-${NAME}
 parameters:
 - description: Storage capacity required for volume claims
   name: STORAGE_CAPACITY

--- a/generated/topic-inmemory-template.yaml
+++ b/generated/topic-inmemory-template.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Template
 metadata:
   labels:
-    addressType: topic
     app: enmasse
   name: topic-inmemory
 objects:
@@ -11,11 +10,8 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      address: "${ADDRESS}"
+      address_config: address-config-${NAME}
       app: enmasse
-      multicast: 'true'
-      store_and_forward: 'true'
-      type: address-config
     name: "${NAME}"
   spec:
     replicas: 1
@@ -119,6 +115,16 @@ objects:
           kind: ImageStreamTag
           name: topic-forwarder:latest
       type: ImageChange
+- apiVersion: v1
+  data:
+    "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: enmasse
+      group_id: "${NAME}"
+      type: address-config
+    name: address-config-${NAME}
 parameters:
 - description: Storage capacity required for volume claims
   name: STORAGE_CAPACITY

--- a/generated/topic-persisted-template.yaml
+++ b/generated/topic-persisted-template.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Template
 metadata:
   labels:
-    addressType: topic
     app: enmasse
   name: topic-persisted
 objects:
@@ -23,11 +22,8 @@ objects:
   kind: DeploymentConfig
   metadata:
     labels:
-      address: "${ADDRESS}"
+      address_config: address-config-${NAME}
       app: enmasse
-      multicast: 'true'
-      store_and_forward: 'true'
-      type: address-config
     name: "${NAME}"
   spec:
     replicas: 1
@@ -132,6 +128,16 @@ objects:
           kind: ImageStreamTag
           name: topic-forwarder:latest
       type: ImageChange
+- apiVersion: v1
+  data:
+    "${ADDRESS}": '{"store_and_forward": true, "multicast": true}'
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: enmasse
+      group_id: "${NAME}"
+      type: address-config
+    name: address-config-${NAME}
 parameters:
 - description: Storage capacity required for volume claims
   name: STORAGE_CAPACITY

--- a/include/direct-template.json
+++ b/include/direct-template.json
@@ -12,14 +12,15 @@
       "apiVersion": "v1",
       "kind": "ConfigMap",
       "metadata": {
-        "name": "${NAME}",
+        "name": "address-config-${NAME}",
         "labels": {
           "app": "enmasse",
           "type": "address-config",
-          "address": "${ADDRESS}",
-          "store_and_forward": "false",
-          "multicast": "${MULTICAST}"
+          "group_id": "${NAME}"
         }
+      },
+      "data": {
+        "${ADDRESS}": "{\"store_and_forward\":false, \"multicast\": ${MULTICAST}}"
       }
     }
   ],


### PR DESCRIPTION
This is a refactoring for decoupling deploymentconfig from the configmap holding the address config.