### PR TITLE
Queue scheduler service

### DIFF
--- a/components.jsonnet
+++ b/components.jsonnet
@@ -5,6 +5,7 @@ local broker = import "include/broker.jsonnet";
 local forwarder = import "include/forwarder.jsonnet";
 local qdrouterd = import "include/qdrouterd.jsonnet";
 local addressController = import "include/address-controller.jsonnet";
+local queueScheduler = import "include/queue-scheduler.jsonnet";
 local subserv = import "include/subserv.jsonnet";
 local common = import "include/common.jsonnet";
 local flavor = import "include/flavor.jsonnet";
@@ -27,6 +28,9 @@ local mqttService = import "include/mqtt-service.jsonnet";
   "address-controller-dc.json": addressController.deployment,
   "address-controller-imagestream.json": addressController.imagestream("enmasseproject/address-controller"),
   "address-controller-service.json": addressController.service,
+  "queue-scheduler-dc.json": queueScheduler.deployment,
+  "queue-scheduler-imagestream.json": queueScheduler.imagestream("enmasseproject/queue-scheduler"),
+  "queue-scheduler-service.json": queueScheduler.service,
   "ragent-image-stream.json": ragent.imagestream("enmasseproject/ragent"),
   "ragent-dc.json": ragent.deployment,
   "ragent-service.json": ragent.service,

--- a/generated/enmasse-base-template.yaml
+++ b/generated/enmasse-base-template.yaml
@@ -837,6 +837,77 @@ objects:
     selector:
       name: subserv
 - apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: enmasse
+    name: queue-scheduler
+  spec:
+    ports:
+    - name: amqp
+      port: 55667
+      protocol: TCP
+      targetPort: 55667
+    selector:
+      name: queue-scheduler
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: enmasse
+      name: queue-scheduler
+    name: queue-scheduler
+  spec:
+    replicas: 1
+    selector:
+      name: queue-scheduler
+    template:
+      metadata:
+        labels:
+          app: enmasse
+          name: queue-scheduler
+      spec:
+        containers:
+        - image: queue-scheduler
+          livenessProbe:
+            tcpSocket:
+              port: amqp
+          name: queue-scheduler
+          ports:
+          - containerPort: 55667
+            name: amqp
+            protocol: TCP
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 128Mi
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - queue-scheduler
+        from:
+          kind: ImageStreamTag
+          name: queue-scheduler:latest
+      type: ImageChange
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: enmasse
+    name: queue-scheduler
+  spec:
+    dockerImageRepository: "${QUEUE_SCHEDULER_REPO}"
+    importPolicy:
+      scheduled: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: "${QUEUE_SCHEDULER_REPO}:latest"
+      name: latest
+- apiVersion: v1
   kind: ImageStream
   metadata:
     labels:
@@ -922,6 +993,9 @@ parameters:
 - description: The docker image to use for the address controller
   name: ADDRESS_CONTROLLER_REPO
   value: enmasseproject/address-controller
+- description: The docker image to use for the queue scheduler
+  name: QUEUE_SCHEDULER_REPO
+  value: enmasseproject/queue-scheduler
 - description: The image to use for the router agent
   name: RAGENT_REPO
   value: enmasseproject/ragent

--- a/generated/enmasse-base-template.yaml
+++ b/generated/enmasse-base-template.yaml
@@ -19,23 +19,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: QUEUE_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -102,6 +105,7 @@ objects:
     metadata:
       labels:
         app: enmasse
+        group_id: "${NAME}"
       name: pvc-${NAME}
     spec:
       accessModes:
@@ -115,23 +119,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: QUEUE_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -200,23 +207,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: TOPIC_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -338,6 +348,7 @@ objects:
     metadata:
       labels:
         app: enmasse
+        group_id: "${NAME}"
       name: pvc-${NAME}
     spec:
       accessModes:
@@ -351,23 +362,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: TOPIC_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:

--- a/generated/enmasse-template.yaml
+++ b/generated/enmasse-template.yaml
@@ -19,23 +19,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: QUEUE_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -102,6 +105,7 @@ objects:
     metadata:
       labels:
         app: enmasse
+        group_id: "${NAME}"
       name: pvc-${NAME}
     spec:
       accessModes:
@@ -115,23 +119,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: QUEUE_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -200,23 +207,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: TOPIC_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -338,6 +348,7 @@ objects:
     metadata:
       labels:
         app: enmasse
+        group_id: "${NAME}"
       name: pvc-${NAME}
     spec:
       accessModes:
@@ -351,23 +362,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: TOPIC_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -954,6 +968,14 @@ objects:
         from:
           kind: ImageStreamTag
           name: address-controller:latest
+      type: ImageChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - queue-scheduler
+        from:
+          kind: ImageStreamTag
+          name: queue-scheduler:latest
       type: ImageChange
 - apiVersion: v1
   kind: Service

--- a/generated/enmasse-template.yaml
+++ b/generated/enmasse-template.yaml
@@ -813,6 +813,21 @@ objects:
         name: "${ADDRESS_CONTROLLER_REPO}:latest"
       name: latest
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: enmasse
+    name: queue-scheduler
+  spec:
+    dockerImageRepository: "${QUEUE_SCHEDULER_REPO}"
+    importPolicy:
+      scheduled: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: "${QUEUE_SCHEDULER_REPO}:latest"
+      name: latest
+- apiVersion: v1
   data:
     json: '{"large-persisted-queue": {"templateName": "queue-persisted", "templateParameters":
       {"STORAGE_CAPACITY": "10Gi"}}, "large-persisted-topic": {"templateName": "topic-persisted",
@@ -880,6 +895,25 @@ objects:
               memory: 64Mi
             requests:
               memory: 64Mi
+        - env:
+          - name: CONFIGURATION_SERVICE_HOST
+            value: localhost
+          - name: CONFIGURATION_SERVICE_PORT
+            value: '5672'
+          image: queue-scheduler
+          livenessProbe:
+            tcpSocket:
+              port: amqp
+          name: queue-scheduler
+          ports:
+          - containerPort: 55667
+            name: amqp
+            protocol: TCP
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 128Mi
         - image: configserv
           livenessProbe:
             tcpSocket:
@@ -937,6 +971,8 @@ objects:
       port: 5672
     - name: address-controller
       port: 55674
+    - name: queue-scheduler
+      port: 55667
     selector:
       name: admin
 parameters:
@@ -958,6 +994,9 @@ parameters:
 - description: The docker image to use for the address controller
   name: ADDRESS_CONTROLLER_REPO
   value: enmasseproject/address-controller
+- description: The docker image to use for the queue scheduler
+  name: QUEUE_SCHEDULER_REPO
+  value: enmasseproject/queue-scheduler
 - description: The image to use for the router agent
   name: RAGENT_REPO
   value: enmasseproject/ragent

--- a/generated/queue-inmemory-template.yaml
+++ b/generated/queue-inmemory-template.yaml
@@ -12,23 +12,26 @@ objects:
     labels:
       address_config: address-config-${NAME}
       app: enmasse
+      group_id: "${NAME}"
     name: "${NAME}"
   spec:
     replicas: 1
     selector:
-      address: "${ADDRESS}"
+      group_id: "${NAME}"
       role: broker
     template:
       metadata:
         labels:
-          address: "${ADDRESS}"
           app: enmasse
+          group_id: "${NAME}"
           role: broker
       spec:
         containers:
         - env:
           - name: QUEUE_NAME
             value: "${ADDRESS}"
+          - name: GROUP_ID
+            value: "${NAME}"
           image: artemis
           lifecycle:
             preStop:

--- a/generated/queue-persisted-template.yaml
+++ b/generated/queue-persisted-template.yaml
@@ -11,6 +11,7 @@ objects:
   metadata:
     labels:
       app: enmasse
+      group_id: "${NAME}"
     name: pvc-${NAME}
   spec:
     accessModes:
@@ -24,23 +25,26 @@ objects:
     labels:
       address_config: address-config-${NAME}
       app: enmasse
+      group_id: "${NAME}"
     name: "${NAME}"
   spec:
     replicas: 1
     selector:
-      address: "${ADDRESS}"
+      group_id: "${NAME}"
       role: broker
     template:
       metadata:
         labels:
-          address: "${ADDRESS}"
           app: enmasse
+          group_id: "${NAME}"
           role: broker
       spec:
         containers:
         - env:
           - name: QUEUE_NAME
             value: "${ADDRESS}"
+          - name: GROUP_ID
+            value: "${NAME}"
           image: artemis
           lifecycle:
             preStop:

--- a/generated/tls-enmasse-base-template.yaml
+++ b/generated/tls-enmasse-base-template.yaml
@@ -19,23 +19,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: QUEUE_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -105,6 +108,7 @@ objects:
     metadata:
       labels:
         app: enmasse
+        group_id: "${NAME}"
       name: pvc-${NAME}
     spec:
       accessModes:
@@ -118,23 +122,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: QUEUE_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -206,23 +213,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: TOPIC_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -354,6 +364,7 @@ objects:
     metadata:
       labels:
         app: enmasse
+        group_id: "${NAME}"
       name: pvc-${NAME}
     spec:
       accessModes:
@@ -367,23 +378,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: TOPIC_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:

--- a/generated/tls-enmasse-base-template.yaml
+++ b/generated/tls-enmasse-base-template.yaml
@@ -878,6 +878,77 @@ objects:
     selector:
       name: subserv
 - apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: enmasse
+    name: queue-scheduler
+  spec:
+    ports:
+    - name: amqp
+      port: 55667
+      protocol: TCP
+      targetPort: 55667
+    selector:
+      name: queue-scheduler
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: enmasse
+      name: queue-scheduler
+    name: queue-scheduler
+  spec:
+    replicas: 1
+    selector:
+      name: queue-scheduler
+    template:
+      metadata:
+        labels:
+          app: enmasse
+          name: queue-scheduler
+      spec:
+        containers:
+        - image: queue-scheduler
+          livenessProbe:
+            tcpSocket:
+              port: amqp
+          name: queue-scheduler
+          ports:
+          - containerPort: 55667
+            name: amqp
+            protocol: TCP
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 128Mi
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - queue-scheduler
+        from:
+          kind: ImageStreamTag
+          name: queue-scheduler:latest
+      type: ImageChange
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: enmasse
+    name: queue-scheduler
+  spec:
+    dockerImageRepository: "${QUEUE_SCHEDULER_REPO}"
+    importPolicy:
+      scheduled: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: "${QUEUE_SCHEDULER_REPO}:latest"
+      name: latest
+- apiVersion: v1
   kind: ImageStream
   metadata:
     labels:
@@ -1025,6 +1096,9 @@ parameters:
 - description: The docker image to use for the address controller
   name: ADDRESS_CONTROLLER_REPO
   value: enmasseproject/address-controller
+- description: The docker image to use for the queue scheduler
+  name: QUEUE_SCHEDULER_REPO
+  value: enmasseproject/queue-scheduler
 - description: The image to use for the router agent
   name: RAGENT_REPO
   value: enmasseproject/ragent

--- a/generated/tls-enmasse-template.yaml
+++ b/generated/tls-enmasse-template.yaml
@@ -19,23 +19,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: QUEUE_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -105,6 +108,7 @@ objects:
     metadata:
       labels:
         app: enmasse
+        group_id: "${NAME}"
       name: pvc-${NAME}
     spec:
       accessModes:
@@ -118,23 +122,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: QUEUE_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -206,23 +213,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: TOPIC_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -354,6 +364,7 @@ objects:
     metadata:
       labels:
         app: enmasse
+        group_id: "${NAME}"
       name: pvc-${NAME}
     spec:
       accessModes:
@@ -367,23 +378,26 @@ objects:
       labels:
         address_config: address-config-${NAME}
         app: enmasse
+        group_id: "${NAME}"
       name: "${NAME}"
     spec:
       replicas: 1
       selector:
-        address: "${ADDRESS}"
+        group_id: "${NAME}"
         role: broker
       template:
         metadata:
           labels:
-            address: "${ADDRESS}"
             app: enmasse
+            group_id: "${NAME}"
             role: broker
         spec:
           containers:
           - env:
             - name: TOPIC_NAME
               value: "${ADDRESS}"
+            - name: GROUP_ID
+              value: "${NAME}"
             image: artemis
             lifecycle:
               preStop:
@@ -1025,6 +1039,14 @@ objects:
         from:
           kind: ImageStreamTag
           name: address-controller:latest
+      type: ImageChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - queue-scheduler
+        from:
+          kind: ImageStreamTag
+          name: queue-scheduler:latest
       type: ImageChange
 - apiVersion: v1
   kind: Service

--- a/generated/tls-enmasse-template.yaml
+++ b/generated/tls-enmasse-template.yaml
@@ -884,6 +884,21 @@ objects:
         name: "${ADDRESS_CONTROLLER_REPO}:latest"
       name: latest
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: enmasse
+    name: queue-scheduler
+  spec:
+    dockerImageRepository: "${QUEUE_SCHEDULER_REPO}"
+    importPolicy:
+      scheduled: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: "${QUEUE_SCHEDULER_REPO}:latest"
+      name: latest
+- apiVersion: v1
   data:
     json: '{"large-persisted-queue": {"templateName": "tls-queue-persisted", "templateParameters":
       {"STORAGE_CAPACITY": "10Gi"}}, "large-persisted-topic": {"templateName": "tls-topic-persisted",
@@ -951,6 +966,25 @@ objects:
               memory: 64Mi
             requests:
               memory: 64Mi
+        - env:
+          - name: CONFIGURATION_SERVICE_HOST
+            value: localhost
+          - name: CONFIGURATION_SERVICE_PORT
+            value: '5672'
+          image: queue-scheduler
+          livenessProbe:
+            tcpSocket:
+              port: amqp
+          name: queue-scheduler
+          ports:
+          - containerPort: 55667
+            name: amqp
+            protocol: TCP
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 128Mi
         - image: configserv
           livenessProbe:
             tcpSocket:
@@ -1008,6 +1042,8 @@ objects:
       port: 5672
     - name: address-controller
       port: 55674
+    - name: queue-scheduler
+      port: 55667
     selector:
       name: admin
 - apiVersion: v1
@@ -1061,6 +1097,9 @@ parameters:
 - description: The docker image to use for the address controller
   name: ADDRESS_CONTROLLER_REPO
   value: enmasseproject/address-controller
+- description: The docker image to use for the queue scheduler
+  name: QUEUE_SCHEDULER_REPO
+  value: enmasseproject/queue-scheduler
 - description: The image to use for the router agent
   name: RAGENT_REPO
   value: enmasseproject/ragent

--- a/generated/tls-queue-inmemory-template.yaml
+++ b/generated/tls-queue-inmemory-template.yaml
@@ -12,23 +12,26 @@ objects:
     labels:
       address_config: address-config-${NAME}
       app: enmasse
+      group_id: "${NAME}"
     name: "${NAME}"
   spec:
     replicas: 1
     selector:
-      address: "${ADDRESS}"
+      group_id: "${NAME}"
       role: broker
     template:
       metadata:
         labels:
-          address: "${ADDRESS}"
           app: enmasse
+          group_id: "${NAME}"
           role: broker
       spec:
         containers:
         - env:
           - name: QUEUE_NAME
             value: "${ADDRESS}"
+          - name: GROUP_ID
+            value: "${NAME}"
           image: artemis
           lifecycle:
             preStop:

--- a/generated/tls-queue-persisted-template.yaml
+++ b/generated/tls-queue-persisted-template.yaml
@@ -11,6 +11,7 @@ objects:
   metadata:
     labels:
       app: enmasse
+      group_id: "${NAME}"
     name: pvc-${NAME}
   spec:
     accessModes:
@@ -24,23 +25,26 @@ objects:
     labels:
       address_config: address-config-${NAME}
       app: enmasse
+      group_id: "${NAME}"
     name: "${NAME}"
   spec:
     replicas: 1
     selector:
-      address: "${ADDRESS}"
+      group_id: "${NAME}"
       role: broker
     template:
       metadata:
         labels:
-          address: "${ADDRESS}"
           app: enmasse
+          group_id: "${NAME}"
           role: broker
       spec:
         containers:
         - env:
           - name: QUEUE_NAME
             value: "${ADDRESS}"
+          - name: GROUP_ID
+            value: "${NAME}"
           image: artemis
           lifecycle:
             preStop:

--- a/generated/tls-topic-inmemory-template.yaml
+++ b/generated/tls-topic-inmemory-template.yaml
@@ -12,23 +12,26 @@ objects:
     labels:
       address_config: address-config-${NAME}
       app: enmasse
+      group_id: "${NAME}"
     name: "${NAME}"
   spec:
     replicas: 1
     selector:
-      address: "${ADDRESS}"
+      group_id: "${NAME}"
       role: broker
     template:
       metadata:
         labels:
-          address: "${ADDRESS}"
           app: enmasse
+          group_id: "${NAME}"
           role: broker
       spec:
         containers:
         - env:
           - name: TOPIC_NAME
             value: "${ADDRESS}"
+          - name: GROUP_ID
+            value: "${NAME}"
           image: artemis
           lifecycle:
             preStop:

--- a/generated/tls-topic-persisted-template.yaml
+++ b/generated/tls-topic-persisted-template.yaml
@@ -11,6 +11,7 @@ objects:
   metadata:
     labels:
       app: enmasse
+      group_id: "${NAME}"
     name: pvc-${NAME}
   spec:
     accessModes:
@@ -24,23 +25,26 @@ objects:
     labels:
       address_config: address-config-${NAME}
       app: enmasse
+      group_id: "${NAME}"
     name: "${NAME}"
   spec:
     replicas: 1
     selector:
-      address: "${ADDRESS}"
+      group_id: "${NAME}"
       role: broker
     template:
       metadata:
         labels:
-          address: "${ADDRESS}"
           app: enmasse
+          group_id: "${NAME}"
           role: broker
       spec:
         containers:
         - env:
           - name: TOPIC_NAME
             value: "${ADDRESS}"
+          - name: GROUP_ID
+            value: "${NAME}"
           image: artemis
           lifecycle:
             preStop:

--- a/generated/topic-inmemory-template.yaml
+++ b/generated/topic-inmemory-template.yaml
@@ -12,23 +12,26 @@ objects:
     labels:
       address_config: address-config-${NAME}
       app: enmasse
+      group_id: "${NAME}"
     name: "${NAME}"
   spec:
     replicas: 1
     selector:
-      address: "${ADDRESS}"
+      group_id: "${NAME}"
       role: broker
     template:
       metadata:
         labels:
-          address: "${ADDRESS}"
           app: enmasse
+          group_id: "${NAME}"
           role: broker
       spec:
         containers:
         - env:
           - name: TOPIC_NAME
             value: "${ADDRESS}"
+          - name: GROUP_ID
+            value: "${NAME}"
           image: artemis
           lifecycle:
             preStop:

--- a/generated/topic-persisted-template.yaml
+++ b/generated/topic-persisted-template.yaml
@@ -11,6 +11,7 @@ objects:
   metadata:
     labels:
       app: enmasse
+      group_id: "${NAME}"
     name: pvc-${NAME}
   spec:
     accessModes:
@@ -24,23 +25,26 @@ objects:
     labels:
       address_config: address-config-${NAME}
       app: enmasse
+      group_id: "${NAME}"
     name: "${NAME}"
   spec:
     replicas: 1
     selector:
-      address: "${ADDRESS}"
+      group_id: "${NAME}"
       role: broker
     template:
       metadata:
         labels:
-          address: "${ADDRESS}"
           app: enmasse
+          group_id: "${NAME}"
           role: broker
       spec:
         containers:
         - env:
           - name: TOPIC_NAME
             value: "${ADDRESS}"
+          - name: GROUP_ID
+            value: "${NAME}"
           image: artemis
           lifecycle:
             preStop:

--- a/include/admin.jsonnet
+++ b/include/admin.jsonnet
@@ -63,7 +63,8 @@ local common = import "common.jsonnet";
         },
         common.trigger("ragent", "ragent"),
         common.trigger("configserv", "configserv"),
-        common.trigger("address-controller", "address-controller")
+        common.trigger("address-controller", "address-controller"),
+        common.trigger("queue-scheduler", "queue-scheduler")
       ],
       "template": {
         "metadata": {

--- a/include/admin.jsonnet
+++ b/include/admin.jsonnet
@@ -29,6 +29,10 @@ local common = import "common.jsonnet";
           {
             "name": "address-controller",
             "port": 55674
+          },
+          {
+            "name": "queue-scheduler",
+            "port": 55667
           }
         ],
         "selector": {
@@ -81,6 +85,15 @@ local common = import "common.jsonnet";
                         "name": "CONFIGURATION_SERVICE_PORT",
                         "value": "5672"
                       }], "64Mi"),
+            common.containerWithEnv("queue-scheduler", "queue-scheduler", "amqp", 55667, [
+                      {
+                        "name": "CONFIGURATION_SERVICE_HOST",
+                        "value": "localhost"
+                      },
+                      {
+                        "name": "CONFIGURATION_SERVICE_PORT",
+                        "value": "5672"
+                      }], "128Mi"),
             common.container("configserv", "configserv", "amqp", 5672, "256Mi"),
           ]
         }

--- a/include/broker.jsonnet
+++ b/include/broker.jsonnet
@@ -17,7 +17,7 @@ local common = import "common.jsonnet";
           "containerPort": 61616
         }
       ],
-      "env": [ addressEnv ],
+      "env": [ addressEnv, {"name": "GROUP_ID", "value": "${NAME}"} ],
       "volumeMounts": [
         {
           "name": volumeName,

--- a/include/enmasse-template-full.jsonnet
+++ b/include/enmasse-template-full.jsonnet
@@ -6,6 +6,7 @@ local broker = import "broker.jsonnet";
 local forwarder = import "forwarder.jsonnet";
 local qdrouterd = import "qdrouterd.jsonnet";
 local addressController = import "address-controller.jsonnet";
+local queueScheduler = import "queue-scheduler.jsonnet";
 local subserv = import "subserv.jsonnet";
 local messagingService = import "messaging-service.jsonnet";
 local messagingRoute = import "messaging-route.json";
@@ -50,6 +51,9 @@ local mqttRoute = import "mqtt-route.json";
                  subserv.imagestream("${SUBSERV_REPO}"),
                  subserv.deployment,
                  subserv.service,
+                 queueScheduler.service,
+                 queueScheduler.deployment,
+                 queueScheduler.imagestream("${QUEUE_SCHEDULER_REPO}"),
                  mqtt.imagestream("${MQTT_GATEWAY_REPO}"),
                  mqttGateway.deployment(secure),
                  mqttService.generate(secure) ],
@@ -93,6 +97,11 @@ local mqttRoute = import "mqtt-route.json";
         "name": "ADDRESS_CONTROLLER_REPO",
         "description": "The docker image to use for the address controller",
         "value": "enmasseproject/address-controller"
+      },
+      {
+        "name": "QUEUE_SCHEDULER_REPO",
+        "description": "The docker image to use for the queue scheduler",
+        "value": "enmasseproject/queue-scheduler"
       },
       {
         "name": "RAGENT_REPO",

--- a/include/enmasse-template.jsonnet
+++ b/include/enmasse-template.jsonnet
@@ -6,6 +6,7 @@ local broker = import "broker.jsonnet";
 local forwarder = import "forwarder.jsonnet";
 local qdrouterd = import "qdrouterd.jsonnet";
 local addressController = import "address-controller.jsonnet";
+local queueScheduler = import "queue-scheduler.jsonnet";
 local subserv = import "subserv.jsonnet";
 local messagingService = import "messaging-service.jsonnet";
 local messagingRoute = import "messaging-route.json";
@@ -51,6 +52,7 @@ local mqttRoute = import "mqtt-route.json";
                  mqttGateway.deployment(secure),
                  mqttService.generate(secure),
                  addressController.imagestream("${ADDRESS_CONTROLLER_REPO}"),
+                 queueScheduler.imagestream("${QUEUE_SCHEDULER_REPO}"),
                  flavorConfig.generate(secure),
                  admin.deployment ] + admin.services,
 
@@ -86,6 +88,11 @@ local mqttRoute = import "mqtt-route.json";
         "name": "ADDRESS_CONTROLLER_REPO",
         "description": "The docker image to use for the address controller",
         "value": "enmasseproject/address-controller"
+      },
+      {
+        "name": "QUEUE_SCHEDULER_REPO",
+        "description": "The docker image to use for the queue scheduler",
+        "value": "enmasseproject/queue-scheduler"
       },
       {
         "name": "RAGENT_REPO",

--- a/include/queue-scheduler.jsonnet
+++ b/include/queue-scheduler.jsonnet
@@ -1,0 +1,45 @@
+local version = std.extVar("VERSION");
+local common = import "common.jsonnet";
+{
+  imagestream(image_name)::
+    common.imagestream("queue-scheduler", image_name),
+  service::
+    common.service("queue-scheduler", "queue-scheduler", "amqp", 55667, 55667),
+  deployment::
+    {
+      "apiVersion": "v1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "labels": {
+          "name": "queue-scheduler",
+          "app": "enmasse"
+        },
+        "name": "queue-scheduler"
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "name": "queue-scheduler"
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          common.trigger("queue-scheduler", "queue-scheduler")
+        ],
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "queue-scheduler",
+              "app": "enmasse"
+            }
+          },
+          "spec": {
+            "containers": [
+              common.container("queue-scheduler", "queue-scheduler", "amqp", 55667, "128Mi")
+            ]
+          }
+        }
+      }
+    }
+}

--- a/include/storage-template.jsonnet
+++ b/include/storage-template.jsonnet
@@ -26,13 +26,14 @@ local forwarder = import "forwarder.jsonnet";
           "name": "${NAME}",
           "labels": {
             "app": "enmasse",
+            "group_id": "${NAME}",
             "address_config": "address-config-${NAME}"
           }
         },
         "spec": {
           "replicas": 1,
           "selector": {
-            "address": "${ADDRESS}",
+            "group_id": "${NAME}",
             "role": "broker"
           },
           local commonTriggers = [
@@ -89,7 +90,7 @@ local forwarder = import "forwarder.jsonnet";
               "labels": {
                 "app": "enmasse",
                 "role": "broker",
-                "address": "${ADDRESS}"
+                "group_id": "${NAME}"
               }
             },
             "spec": {
@@ -113,6 +114,7 @@ local forwarder = import "forwarder.jsonnet";
         "metadata": {
           "name": claimName,
           "labels": {
+            "group_id": "${NAME}",
             "app": "enmasse"
           }
         },


### PR DESCRIPTION
This adds the queue scheduler service to the admin pod if compact, and as a standalone service if not. It also adds the group id to templates, so that the launch scripts and address controller can distinguish groups.