### PR TITLE
Openshift build

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ serviceaccount (system:serviceaccount:myproject:default for a project
 named myproject). This is needed by the configmap-bridge and the
 router agent.
 
-Edit rights must also be granted to the deployer role, used by the
-address-controller.
+A service-account for enmasse-service-account must be created.  Edit 
+rights must also be granted to the enmasse-service-account role, used
+by the address-controller.
 
 The permissions can be setup with the following commands:
 
+    oc create sa enmasse-service-account -n $(oc project -q)
     oc policy add-role-to-user view system:serviceaccount:$(oc project -q):default
-    oc policy add-role-to-user edit system:serviceaccount:$(oc project -q):deployer
+    oc policy add-role-to-user edit system:serviceaccount:$(oc project -q):enmasse-service-account
 
 ## Using the simple template
 

--- a/generated/enmasse-template-with-kafka.yaml
+++ b/generated/enmasse-template-with-kafka.yaml
@@ -756,7 +756,7 @@ objects:
               memory: 256Mi
             requests:
               memory: 256Mi
-        serviceAccount: deployer
+        serviceAccount: enmasse-service-account
 - apiVersion: v1
   kind: Service
   metadata:

--- a/generated/enmasse-template.yaml
+++ b/generated/enmasse-template.yaml
@@ -708,7 +708,7 @@ objects:
               memory: 256Mi
             requests:
               memory: 256Mi
-        serviceAccount: deployer
+        serviceAccount: enmasse-service-account
 - apiVersion: v1
   kind: Service
   metadata:

--- a/generated/tls-enmasse-template-with-kafka.yaml
+++ b/generated/tls-enmasse-template-with-kafka.yaml
@@ -819,7 +819,7 @@ objects:
               memory: 256Mi
             requests:
               memory: 256Mi
-        serviceAccount: deployer
+        serviceAccount: enmasse-service-account
 - apiVersion: v1
   kind: Service
   metadata:

--- a/generated/tls-enmasse-template.yaml
+++ b/generated/tls-enmasse-template.yaml
@@ -771,7 +771,7 @@ objects:
               memory: 256Mi
             requests:
               memory: 256Mi
-        serviceAccount: deployer
+        serviceAccount: enmasse-service-account
 - apiVersion: v1
   kind: Service
   metadata:

--- a/include/address-controller.jsonnet
+++ b/include/address-controller.jsonnet
@@ -26,7 +26,7 @@ local common = import "common.jsonnet";
             }
           },
           "spec": {
-            "serviceAccount": "deployer",
+            "serviceAccount": "enmasse-service-account",
             "containers": [
               common.container("address-controller", image_repo, "amqp", 55674, "256Mi")
             ]

--- a/include/admin.jsonnet
+++ b/include/admin.jsonnet
@@ -62,7 +62,7 @@ local common = import "common.jsonnet";
           }
         },
         "spec": {
-          "serviceAccount": "deployer",
+          "serviceAccount": "enmasse-service-account",
           "containers": [
             common.container2("address-controller", controller_image, "amqp", 55674, "http", 8080, "256Mi"),
             common.containerWithEnv("ragent", ragent_image, "amqp", 55672, [

--- a/scripts/enmasse-deploy.sh
+++ b/scripts/enmasse-deploy.sh
@@ -129,9 +129,9 @@ if [ "$CURRENT_PROJECT" != "$PROJECT" ]; then
     oc new-project $PROJECT
 fi
 
-# oc create sa enmasse -n $PROJECT
+oc create sa enmasse-service-account -n $PROJECT
 oc policy add-role-to-user view system:serviceaccount:${PROJECT}:default
-oc policy add-role-to-user edit system:serviceaccount:${PROJECT}:deployer
+oc policy add-role-to-user edit system:serviceaccount:${PROJECT}:enmasse-service-account
 
 
 if [ -n "$SERVER_KEY" ] && [ -n "$SERVER_CERT" ]


### PR DESCRIPTION
Created a new service account 'enmasse-service-account' to use instead of the 'deployer' service account.  The 'deployer' service account is reserved for the DeploymentConfigs.